### PR TITLE
FIX: enforcing contiguous array when saving output data.

### DIFF
--- a/pyelastix.py
+++ b/pyelastix.py
@@ -653,6 +653,8 @@ def _write_image_data(im, id):
     f = open(fname_raw, 'wb')
     try:
         f.write(im.data)
+    except:
+        f.write(np.ascontiguousarray(im.data))
     finally:
         f.close()
     


### PR DESCRIPTION
Fixing BufferError: memoryview: underlying buffer is not C-contiguous when pyelastics writes output image data.